### PR TITLE
Test and fix for #14

### DIFF
--- a/qumulo_client.py
+++ b/qumulo_client.py
@@ -6,6 +6,7 @@ import sys
 
 import qumulo.lib.auth
 import qumulo.lib.request
+import qumulo.rest
 
 
 class QumuloClient(object):
@@ -13,8 +14,6 @@ class QumuloClient(object):
     def __init__(self, cluster_cfg):
         self.port = cluster_cfg.port
         self.nodes = cluster_cfg.nodes
-        self.retries = cluster_cfg.retries
-        self.retry_delay = cluster_cfg.retry_delay
         self.user = os.getenv('SNMP_AGENT_REST_USER', 'admin')
         self.pwd = os.getenv('SNMP_AGENT_REST_PWD', 'admin')
         self.ipmi_user = os.getenv('SNMP_AGENT_IPMI_USER', 'ADMIN')

--- a/snmp_agent.cfg.template
+++ b/snmp_agent.cfg.template
@@ -4,8 +4,6 @@ clusters:
     {
       name: "clustername"
       port:8000
-      retries:10
-      retry_delay:10
       # use persistent IP addresses instead of floating here
       # listing them in node order is helpful
       nodes: [ "10.220.200.1",

--- a/test_qumulo_client.py
+++ b/test_qumulo_client.py
@@ -131,3 +131,12 @@ class TestRestClient(TestCase):
         QC = qumulo_client.QumuloClient(dummy_cfg)
         result = QC.get_drive_states()
         self.assertIsNone(result)
+
+    def test_get_api_response_credentials_timeout(self):
+        """instantiate client, blow away credentials, assert api call works"""
+        dummy_cfg = DummyConfig()
+        QC = qumulo_client.QumuloClient(dummy_cfg)
+        # no credentials behave the same way as expired credentials
+        QC.credentials = None
+        response = QC.get_api_response(qumulo.rest.cluster.list_nodes)
+        self.assertIsNotNone(response)


### PR DESCRIPTION
removed a bit of unnecessary retry foo in get_api_response() since
we’re polling. We may want to add the ability to try different nodes in
the future in case the node we’re talking to is down.